### PR TITLE
:bug: (ChibiUploader) change character set from default latin1 to utf8

### DIFF
--- a/packages/uploader-module/src/index.ts
+++ b/packages/uploader-module/src/index.ts
@@ -246,7 +246,8 @@ export const processFile = async (req: IncomingMessage, options: Options) => {
 					files: 1,
 					// We add an extra 1024 bytes to the maxChunkSize to account for the metadata
 					fileSize: options.maxChunkSize + 1024
-				}
+				},
+				defParamCharset: 'utf8'
 			});
 
 			busboy.on('file', (fieldname, fileStream, info) => {


### PR DESCRIPTION
The default charset for multipart forms is latin1 in Busboy. Manually set it to utf8 to solve unicode compatible problem.

I write more details in https://github.com/chibisafe/chibisafe/issues/537